### PR TITLE
Make the little drop icon show up when hovering over drop zones

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -99,7 +99,7 @@ view model =
                 ]
             ]
         , div [ class "d-flex justify-content-center" ]
-            [ ul [ class "list-unstyled d-flex flex-column align-items-center" ] (List.Extra.interweave (List.indexedMap viewBullet model.items) (List.indexedMap viewDropZone model.items)) ]
+            [ ul [ class "list-unstyled flex-column align-items-center" ] (List.Extra.interweave (List.indexedMap viewBullet model.items) (List.indexedMap viewDropZone model.items)) ]
         ]
 
 
@@ -198,7 +198,7 @@ insertItem index item list =
 
 viewDropZone : Int -> Bullet -> Html Msg
 viewDropZone index b =
-    div (Html5.DragDrop.droppable DragDropMsg index ++ [ class "m-2" ]) []
+    hr (Html5.DragDrop.droppable DragDropMsg index ++ [ class "m-2" ]) []
 
 
 viewBullet : Int -> Bullet -> Html Msg


### PR DESCRIPTION
It was a simple change, though it took a while to find. Apparently I totally misled you when we talked about just using a `div` for the drop zone. I also had to remove the `d-flex` class for some unknown reason. `hr` here is short for "horizontal rule" and displays a thin horizontal line.

The aesthetic changes look really nice - good work with that!